### PR TITLE
Couple of things

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ operator-remove-openshift:
 	oc delete --ignore-not-found=true -n kiali-operator -f deploy/role.yaml
 	oc delete --ignore-not-found=true -n kiali-operator -f deploy/role_binding.yaml
 	oc delete --ignore-not-found=true -n kiali-operator -f deploy/operator.yaml
-	oc delete namespace kiali-test-mesh-operator --ignore-not-found=true
+	oc delete namespace kiali-operator --ignore-not-found=true
 
 deploy-kiali:
 	@echo Deploy Kiali CR

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,34 @@
+OPERATOR_IMAGE ?= kiali/kiali-operator:latest
+
+
+operator-build:
+	@echo Building operator
+	operator-sdk build ${OPERATOR_IMAGE}
+	docker push ${OPERATOR_IMAGE}
+
+operator-deploy-openshift: operator-remove-openshift
+	@echo Deploying Operator
+	oc new-project kiali-operator
+	oc apply -n kiali-operator -f crds/op_v1alpha1_kiali_crd.yaml
+	oc apply -n kiali-operator -f service_account.yaml
+	oc apply -n kiali-operator -f role.yaml
+	oc apply -n kiali-operator -f role_binding.yaml
+	oc apply -n kiali-operator -f operator.yaml
+
+operator-remove-openshift:
+	@echo Removing Operator
+	oc delete --ignore-not-found=true -n kiali-operator -f crds/op_v1alpha1_kiali_crd.yaml
+	oc delete --ignore-not-found=true -n kiali-operator -f service_account.yaml
+	oc delete --ignore-not-found=true -n kiali-operator -f role.yaml
+	oc delete --ignore-not-found=true -n kiali-operator -f role_binding.yaml
+	oc delete --ignore-not-found=true -n kiali-operator -f operator.yaml
+	oc delete namespace kiali-test-mesh-operator --ignore-not-found=true
+
+deploy-kiali:
+	@echo Deploy Kiali CR
+	oc apply -n kiali-operator -f crds/op_v1alpha1_kiali_cr.yaml
+
+
+remove-kiali: 
+	@echo Remove Kiali CR
+	oc delete --ignore-not-found=true -n kiali-operator -f crds/op_v1alpha1_kiali_cr.yaml

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-OPERATOR_IMAGE ?= kiali/kiali-operator:latest
+OPERATOR_IMAGE ?= gbaufake/kiali-operator:latest
 
 
 operator-build:
@@ -9,19 +9,19 @@ operator-build:
 operator-deploy-openshift: operator-remove-openshift
 	@echo Deploying Operator
 	oc new-project kiali-operator
-	oc apply -n kiali-operator -f crds/op_v1alpha1_kiali_crd.yaml
-	oc apply -n kiali-operator -f service_account.yaml
-	oc apply -n kiali-operator -f role.yaml
-	oc apply -n kiali-operator -f role_binding.yaml
-	oc apply -n kiali-operator -f operator.yaml
+	oc apply -n kiali-operator -f deploy/crds/op_v1alpha1_kiali_crd.yaml
+	oc apply -n kiali-operator -f deploy/service_account.yaml
+	oc apply -n kiali-operator -f deploy/role.yaml
+	oc apply -n kiali-operator -f deploy/role_binding.yaml
+	oc apply -n kiali-operator -f deploy/operator.yaml
 
 operator-remove-openshift:
 	@echo Removing Operator
-	oc delete --ignore-not-found=true -n kiali-operator -f crds/op_v1alpha1_kiali_crd.yaml
-	oc delete --ignore-not-found=true -n kiali-operator -f service_account.yaml
-	oc delete --ignore-not-found=true -n kiali-operator -f role.yaml
-	oc delete --ignore-not-found=true -n kiali-operator -f role_binding.yaml
-	oc delete --ignore-not-found=true -n kiali-operator -f operator.yaml
+	oc delete --ignore-not-found=true -n kiali-operator -f deploy/crds/op_v1alpha1_kiali_crd.yaml
+	oc delete --ignore-not-found=true -n kiali-operator -f deploy/service_account.yaml
+	oc delete --ignore-not-found=true -n kiali-operator -f deploy/role.yaml
+	oc delete --ignore-not-found=true -n kiali-operator -f deploy/role_binding.yaml
+	oc delete --ignore-not-found=true -n kiali-operator -f deploy/operator.yaml
 	oc delete namespace kiali-test-mesh-operator --ignore-not-found=true
 
 deploy-kiali:

--- a/Makefile
+++ b/Makefile
@@ -26,9 +26,9 @@ operator-remove-openshift:
 
 deploy-kiali:
 	@echo Deploy Kiali CR
-	oc apply -n kiali-operator -f crds/op_v1alpha1_kiali_cr.yaml
+	oc apply -n kiali-operator -f deploy/crds/op_v1alpha1_kiali_cr.yaml
 
 
 remove-kiali: 
 	@echo Remove Kiali CR
-	oc delete --ignore-not-found=true -n kiali-operator -f crds/op_v1alpha1_kiali_cr.yaml
+	oc delete --ignore-not-found=true -n kiali-operator -f deploy/crds/op_v1alpha1_kiali_cr.yaml

--- a/deploy/crds/op_v1alpha1_kiali_cr.yaml
+++ b/deploy/crds/op_v1alpha1_kiali_cr.yaml
@@ -5,15 +5,13 @@ metadata:
 spec:
   state: present
   auth_strategy: openshift
-  kiali_username:
-  kiali_passphrase:
-  #kiali_username_base64:
-  #kiali_passphrase_base64:
+  kiali_username: 'admin'
+  kiali_passphrase: 'admin'
   server_port: 20001
   jaeger_url: "http://jaeger-query-istio-system.127.0.0.1.nip.io"
   grafana_url: "http://grafana-istio-system.127.0.0.1.nip.io"
   image_name: kiali/kiali
-  image_version: lastrelease
+  image_version: latest
   version_label: lastrelease
   image_pull_policy_token: "imagePullPolicy: Always"
   namespace: istio-system

--- a/deploy/crds/op_v1alpha1_kiali_cr.yaml
+++ b/deploy/crds/op_v1alpha1_kiali_cr.yaml
@@ -8,11 +8,9 @@ spec:
   kiali_username: 'admin'
   kiali_passphrase: 'admin'
   server_port: 20001
-  jaeger_url: "http://jaeger-query-istio-system.127.0.0.1.nip.io"
-  grafana_url: "http://grafana-istio-system.127.0.0.1.nip.io"
   image_name: kiali/kiali
   image_version: latest
-  version_label: lastrelease
+  version_label: latest
   image_pull_policy_token: "imagePullPolicy: Always"
   namespace: istio-system
   istio_namespace: istio-system

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -19,7 +19,7 @@ spec:
           - /usr/local/bin/ao-logs
           - /tmp/ansible-operator/runner
           - stdout
-          image: kiali/kiali-operator:0.1
+          image: gbaufake/kiali-operator:latest
           imagePullPolicy: "IfNotPresent"
           volumeMounts:
           - mountPath: /tmp/ansible-operator/runner
@@ -27,7 +27,7 @@ spec:
             readOnly: true
         - name: operator
           # Replace this with the built image name
-          image: kiali/kiali-operator:0.1
+          image: gbaufake/kiali-operator:latest
           imagePullPolicy: "IfNotPresent"
           volumeMounts:
           - mountPath: /tmp/ansible-operator/runner

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -14,6 +14,7 @@ rules:
   - secrets
   - services
   - serviceaccounts
+  - clusterrolebindings
   verbs:
   - '*'
 - apiGroups:

--- a/roles/kiali/defaults/main.yml
+++ b/roles/kiali/defaults/main.yml
@@ -1,17 +1,15 @@
 ---
 # defaults file for kiali
 auth_strategy: openshift
-kiali_username:
-kiali_passphrase:
-kiali_username_base64: "YWRtaW4="
-kiali_passphrase_base64: "YWRtaW4="
+kiali_username: 'admin'
+kiali_passphrase: 'admin'
 server_port: 20001
-jaeger_url: "http://jaeger-query-istio-system.127.0.0.1.nip.io"
-grafana_url: "http://grafana-istio-system.127.0.0.1.nip.io"
 image_name: kiali/kiali
-image_version: lastrelease
+image_version: latest
 image_pull_policy_token: "imagePullPolicy: Always"
-#namespace: istio-system
-namespace: kiali-operator
 istio_namespace: istio-system
 verbose_mode: 3
+
+
+state: present
+version_label: latest

--- a/roles/kiali/tasks/grafana.yml
+++ b/roles/kiali/tasks/grafana.yml
@@ -1,0 +1,13 @@
+- name: Detect Grafana Route on Openshift
+  k8s_facts:
+    api_version: route.openshift.io/v1
+    kind: Route
+    name: grafana
+    namespace: "{{ istio_namespace }}"
+  register: grafana_cluster
+  when: openshift
+
+- name: Detect Grafana Route
+  set_fact:
+    grafana_url: "http://{{ grafana_cluster['resources'][0]['status']['ingress'][0]['host'] }}"
+  when: openshift

--- a/roles/kiali/tasks/jaeger.yml
+++ b/roles/kiali/tasks/jaeger.yml
@@ -1,0 +1,13 @@
+- name: Detect Jaeger Route
+  k8s_facts:
+    api_version: route.openshift.io/v1
+    kind: Route
+    name: tracing
+    namespace: "{{ istio_namespace }}"
+  register: jaeger_cluster
+  when: openshift
+
+- name: Detect Jaeger Route
+  set_fact:
+    jaeger_url: "http://{{ jaeger_cluster['resources'][0]['status']['ingress'][0]['host'] }}"
+  when: openshift

--- a/roles/kiali/tasks/main.yml
+++ b/roles/kiali/tasks/main.yml
@@ -1,20 +1,39 @@
----
 - name: "Get information about the cluster"
   set_fact:
     api_groups: "{{ lookup('k8s', cluster_info='api_groups') }}"
 
+- name: "Check if it is openshift"
+  set_fact:
+    openshift: "{{ True if 'route.openshift.io' in api_groups else False }}"
+
+- name: 'Detect Grafana URL when is not defined'
+  include: grafana.yml
+  when: grafana_url is not defined
+
+- name: 'Detect Jaeger URL when is not defined'
+  include: jaeger.yml
+  when: jaeger_url is not defined
+
 - name: 'Set Kiali objects state={{ state }}'
   k8s:
     state: '{{ state }}'
-    definition: "{{ lookup('template', item.name) | from_yaml }}"
-  when: item.api_exists | default(True)
-  loop:
-    - name: secret.yaml
-    - name: configmap.yaml
-    - name: serviceaccount.yaml
-    - name: clusterrole.yaml
-    - name: clusterrolebinding.yaml
-    - name: deployment.yaml
-    - name: service.yaml
-    - name: route.yaml
-      api_exists: "{{ True if 'route.openshift.io' in api_groups else False }}"
+    definition: "{{ lookup('template', item.name) }}"
+  with_items:
+  - {name: 'templates/secret.yaml'}
+  - {name: 'templates/configmap.yaml'}
+  - {name: 'templates/serviceaccount.yaml'}
+  - {name: 'templates/clusterrole.yaml'}
+  - {name: 'templates/clusterrole-viewer.yaml'}
+  - {name: 'templates/service.yaml'}
+  - {name: 'templates/clusterrolebinding.yaml'}
+  - {name: 'templates/deployment.yaml'}
+ 
+
+- name: 'Deploy Kiali Route only on openshift'
+  k8s:
+    state: '{{ state }}'
+    definition: "{{ lookup('template', item.name)}}"
+  when: openshift
+  with_items:
+  - {name: 'templates/route.yaml'}
+

--- a/roles/kiali/templates/clusterrole-viewer.yaml
+++ b/roles/kiali/templates/clusterrole-viewer.yaml
@@ -1,8 +1,8 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: kiali
-  namespace: {{ istio_namespace }}
+  name: kiali-viewer
+  namespace: {{ namespace }}
   labels:
     app: kiali
     version: {{ version_label }}
@@ -76,11 +76,8 @@ rules:
   - statsds
   - stdios
   verbs:
-  - create
-  - delete
   - get
   - list
-  - patch
   - watch
 - apiGroups: ["networking.istio.io"]
   resources:
@@ -89,22 +86,16 @@ rules:
   - serviceentries
   - virtualservices
   verbs:
-  - create
-  - delete
   - get
   - list
-  - patch
   - watch
 - apiGroups: ["authentication.istio.io"]
   resources:
   - policies
   - meshpolicies
   verbs:
-  - create
-  - delete
   - get
   - list
-  - patch
   - watch
 - apiGroups: ["rbac.istio.io"]
   resources:
@@ -113,11 +104,8 @@ rules:
   - serviceroles
   - servicerolebindings
   verbs:
-  - create
-  - delete
   - get
   - list
-  - patch
   - watch
 - apiGroups: ["apps.openshift.io"]
   resources:

--- a/roles/kiali/templates/clusterrolebinding.yaml
+++ b/roles/kiali/templates/clusterrolebinding.yaml
@@ -1,14 +1,16 @@
-apiVersion: v1
+apiVersion: v1beta1
 kind: ClusterRoleBinding
 metadata:
   name: kiali
-  namespace: {{ namespace }}
+  namespace: {{ istio_namespace }}
   labels:
     app: kiali
     version: {{ version_label }}
 roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
   name: kiali
 subjects:
 - kind: ServiceAccount
   name: kiali-service-account
-  namespace: {{ namespace }}
+  namespace: {{ istio_namespace }}

--- a/roles/kiali/templates/configmap.yaml
+++ b/roles/kiali/templates/configmap.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: kiali
-  namespace: {{ namespace }}
+  namespace: {{ istio_namespace }}
   labels:
     app: kiali
     version: {{ version_label }}

--- a/roles/kiali/templates/crds.yaml
+++ b/roles/kiali/templates/crds.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: monitoringdashboards.monitoring.kiali.io
-  namespace: {{ namespace }}
+  namespace: {{ istio_namespace }}
   labels:
     app: kiali
     version: {{ version_label }}

--- a/roles/kiali/templates/deployment.yaml
+++ b/roles/kiali/templates/deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: kiali
-  namespace: {{ namespace }}
+  namespace: {{ istio_namespace }}
   labels:
     app: kiali
     version: {{ version_label }}

--- a/roles/kiali/templates/ingress.yaml
+++ b/roles/kiali/templates/ingress.yaml
@@ -2,7 +2,7 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: kiali
-  namespace: {{ namespace }}
+  namespace: {{ istio_namespace }}
   labels:
     app: kiali
     version: {{ version_label }}

--- a/roles/kiali/templates/oauth.yaml
+++ b/roles/kiali/templates/oauth.yaml
@@ -2,7 +2,7 @@ apiVersion: oauth.openshift.io/v1
 kind: OAuthClient
 metadata:
   name: kiali
-  namespace: {{ namespace }}
+  namespace: {{ istio_namespace }}
   labels:
     app: kiali
 redirectURIs:

--- a/roles/kiali/templates/route.yaml
+++ b/roles/kiali/templates/route.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Route
 metadata:
   name: kiali
-  namespace: {{ namespace }}
+  namespace: {{ istio_namespace }}
   labels:
     app: kiali
     version: {{ version_label }}

--- a/roles/kiali/templates/secret.yaml
+++ b/roles/kiali/templates/secret.yaml
@@ -2,11 +2,11 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: kiali
-  namespace: {{ namespace }}
+  namespace: {{ istio_namespace }}
   labels:
     app: kiali
     version: {{ version_label }}
 type: Opaque
 data:
-  username: {{ kiali_username_base64 }}
-  passphrase: {{ kiali_passphrase_base64 }}
+  username: {{ kiali_username | b64encode}}
+  passphrase: {{ kiali_passphrase | b64encode}}

--- a/roles/kiali/templates/service.yaml
+++ b/roles/kiali/templates/service.yaml
@@ -4,7 +4,7 @@ metadata:
   annotations:
     service.alpha.openshift.io/serving-cert-secret-name: kiali-cert-secret
   name: kiali
-  namespace: {{ namespace }}
+  namespace: {{ istio_namespace }}
   labels:
     app: kiali
     version: {{ version_label }}

--- a/roles/kiali/templates/serviceaccount.yaml
+++ b/roles/kiali/templates/serviceaccount.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: kiali-service-account
-  namespace: {{ namespace }}
+  namespace: {{ istio_namespace }}
   labels:
     app: kiali
     version: {{ version_label }}

--- a/watches.yaml
+++ b/watches.yaml
@@ -3,3 +3,4 @@
   group: op.kiali.io
   kind: Kiali
   role: /opt/ansible/roles/kiali
+  reconcilePeriod: 0


### PR DESCRIPTION
- Renamed the namespace variables to `istio_namespace`
- Included the `rbac.authorization.k8s.io/v1` on `ClusterRole` and `ClusterRoleBinding`
- Separated `kiali-viewer` on its own file because `--` will cause ansible k8s to fail
- Refactored a bit the logic of `openshift_route`
- Include the logic on ansible playbook to encode with base64 during the stage, so the user will have to encode it before.

and as bonus:

- autodetection of openshift routes of jaeger and grafana
- make file to make it simpler